### PR TITLE
Fix link to license file in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,4 +110,4 @@ It turns out `himawari.js` was inspired by [this gist](https://gist.github.com/M
 
 ## License
 
-[ISC](LICENSE)
+[ISC](LICENSE.md)


### PR DESCRIPTION
Turns out that commit 80a1b37658b1ae8f5ff2da918de31f5367ec43cb didn't change the link in the readme file. 

Cheers. :beers: 